### PR TITLE
Fixed Calculations badge alingment on mobile screens

### DIFF
--- a/frontend/templates/frontend/base.html
+++ b/frontend/templates/frontend/base.html
@@ -184,10 +184,10 @@
 						New Molecule
 					</a>
 					<a class="navbar-item" href="/calculations/">
+						Calculations					
 						{% if user.profile.unseen_calculations > 0 %}
 							<span id="unseen_calculations_badge" class="badge is-bottom is-warning">{{ user.profile.unseen_calculations }}</span>
 						{% endif %}
-						Calculations
 					</a>
 
 					<a class="navbar-item" href="https://calcus.readthedocs.io/en/latest/index.html" target="_blank" rel="noopener noreferrer">

--- a/static/frontend/style.css
+++ b/static/frontend/style.css
@@ -5,3 +5,8 @@ li a {
   word-wrap:break-word; 
   word-break: break-all; 
 }
+@media screen and (max-width:1000px) {
+    #unseen_calculations_badge{
+         position: initial;
+    }
+ }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/101187353/165849268-20210ca2-bcce-4eef-a7df-824a8d4ed1f6.png)

-Overrode bulma css badge position from `absolute` to `initial` for screens less than 1000px of width.
