### PR TITLE
Added a header to indicate the name of molecule on CalculationOrder Page

### DIFF
--- a/frontend/templates/frontend/calculationorder.html
+++ b/frontend/templates/frontend/calculationorder.html
@@ -55,6 +55,7 @@
 <div class="container">
 	<div class="box">
 		<center>
+			<header class="title is-2">{{ order.ensemble.parent_molecule.name }}</header>
 			{% if order.ensemble %}
 				<h3 class="title is-h3">Calculation Order {{ order.id }} - {{ order.ensemble.name }}</h3>
 			{% else %}


### PR DESCRIPTION
I have added a header to indicate the name of the molecule on the CalculationOrder page. Below are the screenshots of the implementation.

![image](https://user-images.githubusercontent.com/65958420/171347717-2fdd45eb-cc8d-4035-8859-1aa5a7b54efd.png)

![image](https://user-images.githubusercontent.com/65958420/171348014-40ac8891-0a67-474f-8f99-b73a06ad2ea6.png)
