### PR TITLE
Project is now preselected based on previously selected project when running new calculation

### DIFF
--- a/frontend/templates/frontend/launch.html
+++ b/frontend/templates/frontend/launch.html
@@ -339,7 +339,6 @@
 				field.style.display = "none";	
 				if(project_presets[choice.value] != -1) {
 					load_preset(project_presets[choice.value]);
-					preselect_last_project()
 				}
 				type = document.getElementById("calc_type");
 				if(type.value == "Minimum Energy Path") {
@@ -348,18 +347,24 @@
 
 			}
 		}
-
-		function preselect_last_project() {
-			choice = document.getElementById("calc_project");
-			for(var i=0;i<choice.options.length;i++)
-			{
-				option = choice.options[i];
-				if(option.text == localStorage.getItem("lastSelectedProject") && option.text != "New Project")
+		
+		function project_selection() {
+			var option;
+			{% for proj in profile.project_set.all|dictsort:"name" %}
+				option = document.createElement("option")
+				option.setAttribute("name", "{{ proj.name }}")
+				if("{{ proj.name }}" == localStorage.getItem("lastSelectedProject"))
 				{
-					option.setAttribute('selected', true);
-					return;
+					console.log("Selected")
+					option.selected = true;
 				}
-			}
+				option.innerHTML = "{{ proj.name }}"
+				document.getElementById("calc_project").appendChild(option)
+			{% endfor %}
+				option = document.createElement("option")
+				option.setAttribute("name", "new_project")
+				option.innerHTML =  "New Project"
+				document.getElementById("calc_project").appendChild(option)
 		}
 
 		function refresh_availabilities() {
@@ -1017,12 +1022,8 @@
 							<label class="label">Project</label>
 							<div class="control">
 								<div class="select" >
-								  <select name="calc_project" onchange="project_selection_changed()" id="calc_project">
-									  {% for proj in profile.project_set.all|dictsort:"name" %}
-									  <option name="{{ proj }}">{{ proj }}</option>
-									  {% endfor %}
-									  <option name="new_project">New Project</option>
-								  </select>
+									<select name="calc_project" onchange="project_selection_changed()" id="calc_project">
+									</select>
 								</div>
 							</div>
 						</div>
@@ -1341,6 +1342,7 @@
 
 	$( document ).ready(function() {
 		{% if not ensemble and not structure %}
+		project_selection();
 		project_selection_changed();
 		{% endif %}
 

--- a/frontend/templates/frontend/launch.html
+++ b/frontend/templates/frontend/launch.html
@@ -329,8 +329,7 @@
 			refresh_availabilities();
 		}
 
-		function project_selection_changed() {
-			choice = document.getElementById("calc_project");
+		function project_selection_changed(choice) {
 			field = document.getElementById("new_project_name_field");
 			if(choice.value == "New Project") {
 				field.style.display = "block";
@@ -339,7 +338,6 @@
 				field.style.display = "none";	
 				if(project_presets[choice.value] != -1) {
 					load_preset(project_presets[choice.value]);
-					preselect_last_project()
 				}
 				type = document.getElementById("calc_type");
 				if(type.value == "Minimum Energy Path") {
@@ -357,6 +355,7 @@
 				if(option.text == localStorage.getItem("lastSelectedProject") && option.text != "New Project")
 				{
 					option.setAttribute('selected', true);
+					project_selection_changed(option);
 					return;
 				}
 			}
@@ -1017,7 +1016,7 @@
 							<label class="label">Project</label>
 							<div class="control">
 								<div class="select" >
-								  <select name="calc_project" onchange="project_selection_changed()" id="calc_project">
+								  <select name="calc_project" onchange="project_selection_changed(this)" id="calc_project">
 									  {% for proj in profile.project_set.all|dictsort:"name" %}
 									  <option name="{{ proj }}">{{ proj }}</option>
 									  {% endfor %}
@@ -1341,7 +1340,8 @@
 
 	$( document ).ready(function() {
 		{% if not ensemble and not structure %}
-		project_selection_changed();
+		preselect_last_project();
+		project_selection_changed(document.getElementById("calc_project"));
 		{% endif %}
 
 		refresh_presets();

--- a/frontend/templates/frontend/launch.html
+++ b/frontend/templates/frontend/launch.html
@@ -339,6 +339,7 @@
 				field.style.display = "none";	
 				if(project_presets[choice.value] != -1) {
 					load_preset(project_presets[choice.value]);
+					preselect_last_project()
 				}
 				type = document.getElementById("calc_type");
 				if(type.value == "Minimum Energy Path") {
@@ -347,24 +348,18 @@
 
 			}
 		}
-		
-		function project_selection() {
-			var option;
-			{% for proj in profile.project_set.all|dictsort:"name" %}
-				option = document.createElement("option")
-				option.setAttribute("name", "{{ proj.name }}")
-				if("{{ proj.name }}" == localStorage.getItem("lastSelectedProject"))
+
+		function preselect_last_project() {
+			choice = document.getElementById("calc_project");
+			for(var i=0;i<choice.options.length;i++)
+			{
+				option = choice.options[i];
+				if(option.text == localStorage.getItem("lastSelectedProject") && option.text != "New Project")
 				{
-					console.log("Selected")
-					option.selected = true;
+					option.setAttribute('selected', true);
+					return;
 				}
-				option.innerHTML = "{{ proj.name }}"
-				document.getElementById("calc_project").appendChild(option)
-			{% endfor %}
-				option = document.createElement("option")
-				option.setAttribute("name", "new_project")
-				option.innerHTML =  "New Project"
-				document.getElementById("calc_project").appendChild(option)
+			}
 		}
 
 		function refresh_availabilities() {
@@ -1022,8 +1017,12 @@
 							<label class="label">Project</label>
 							<div class="control">
 								<div class="select" >
-									<select name="calc_project" onchange="project_selection_changed()" id="calc_project">
-									</select>
+								  <select name="calc_project" onchange="project_selection_changed()" id="calc_project">
+									  {% for proj in profile.project_set.all|dictsort:"name" %}
+									  <option name="{{ proj }}">{{ proj }}</option>
+									  {% endfor %}
+									  <option name="new_project">New Project</option>
+								  </select>
 								</div>
 							</div>
 						</div>
@@ -1342,7 +1341,6 @@
 
 	$( document ).ready(function() {
 		{% if not ensemble and not structure %}
-		project_selection();
 		project_selection_changed();
 		{% endif %}
 

--- a/frontend/templates/frontend/launch.html
+++ b/frontend/templates/frontend/launch.html
@@ -144,6 +144,11 @@
 
 		function verify_form() {
 			$("#submit_button").addClass("is-loading");
+			
+			//Adding the selected Project to localStorage on pressing Submit Button
+			choice = document.getElementById("calc_project");
+			localStorage.setItem("lastSelectedProject", choice.value);
+
 			data = $("#calcform").serializeArray(),
 
 			data.push({"name": "constraint_num", "value": constraint_num});
@@ -334,12 +339,26 @@
 				field.style.display = "none";	
 				if(project_presets[choice.value] != -1) {
 					load_preset(project_presets[choice.value]);
+					preselect_last_project()
 				}
 				type = document.getElementById("calc_type");
 				if(type.value == "Minimum Energy Path") {
 					refresh_aux_mol();
 				}
 
+			}
+		}
+
+		function preselect_last_project() {
+			choice = document.getElementById("calc_project");
+			for(var i=0;i<choice.options.length;i++)
+			{
+				option = choice.options[i];
+				if(option.text == localStorage.getItem("lastSelectedProject") && option.text != "New Project")
+				{
+					option.setAttribute('selected', true);
+					return;
+				}
 			}
 		}
 


### PR DESCRIPTION
Now the previously selected project is preselected, when we open the new calculation page. If there is no preselected project, it will by default select the project alphabetically. I have used [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) for this implementation (It stores data without any expiration date) and using the database was unnecessary for this purpose. Below is the screen recording of the implementation.

https://drive.google.com/file/d/1HBEBgid9jqkifrktpU9oRJ-qTyLaAD7C/view?usp=sharing


