### PR TITLE
Fixed cleaning of calculation orders (issue #31)

### DIFF
--- a/frontend/test_selenium.py
+++ b/frontend/test_selenium.py
@@ -1021,13 +1021,13 @@ class InterfaceTests(CalcusLiveServer):
         self.wait_for_ajax()
 
         # Check for frontend removal
-        self.assertEqual(self.get_number_unseen_calcs_manually(), 0)
-        self.assertEqual(self.get_number_calc_orders(), 2)
+        self.assertEqual(self.get_number_unseen_calcs_manually(), 1)
+        self.assertEqual(self.get_number_calc_orders(), 3)
 
         # Check for backend removal
         for i in range(3):
             self.lget("/calculations/")
-            if self.get_number_unseen_calcs() == 0:
+            if self.get_number_unseen_calcs() == 1:
                 break
             time.sleep(1)
         else:

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -5344,10 +5344,11 @@ def clean_all_successful(request):
     to_update = []
     calcs = CalculationOrder.objects.filter(author=request.user, hidden=False)
     for c in calcs:
-        if c.status == 2:
-            c.hidden = True
-            c.see()
-            to_update.append(c)
+        if c.last_seen_status != 0:    #default value of c.last_seen_status is 0, if calculation is not viewed
+            if c.status == 2:
+                c.hidden = True
+                c.see()
+                to_update.append(c)
 
     CalculationOrder.objects.bulk_update(to_update, ["hidden", "last_seen_status"])
 
@@ -5359,10 +5360,11 @@ def clean_all_completed(request):
     to_update = []
     calcs = CalculationOrder.objects.filter(author=request.user, hidden=False)
     for c in calcs:
-        if c.status in [2, 3]:
-            c.hidden = True
-            c.see()
-            to_update.append(c)
+        if c.last_seen_status != 0:   #default value of c.last_seen_status is 0, if calculation is not viewed
+            if c.status in [2, 3]:
+                c.hidden = True
+                c.see()
+                to_update.append(c)
 
     CalculationOrder.objects.bulk_update(to_update, ["hidden", "last_seen_status"])
 

--- a/frontend/views.py
+++ b/frontend/views.py
@@ -5344,11 +5344,12 @@ def clean_all_successful(request):
     to_update = []
     calcs = CalculationOrder.objects.filter(author=request.user, hidden=False)
     for c in calcs:
-        if c.last_seen_status != 0:    #default value of c.last_seen_status is 0, if calculation is not viewed
+        if c.last_seen_status == c.status :    
             if c.status == 2:
-                c.hidden = True
-                c.see()
-                to_update.append(c)
+                if c.hidden == False:
+                    c.hidden = True
+                    c.see()
+                    to_update.append(c)
 
     CalculationOrder.objects.bulk_update(to_update, ["hidden", "last_seen_status"])
 
@@ -5360,11 +5361,12 @@ def clean_all_completed(request):
     to_update = []
     calcs = CalculationOrder.objects.filter(author=request.user, hidden=False)
     for c in calcs:
-        if c.last_seen_status != 0:   #default value of c.last_seen_status is 0, if calculation is not viewed
+        if c.last_seen_status == c.status :   
             if c.status in [2, 3]:
-                c.hidden = True
-                c.see()
-                to_update.append(c)
+                if c.hidden == False:
+                    c.hidden = True
+                    c.see()
+                    to_update.append(c)
 
     CalculationOrder.objects.bulk_update(to_update, ["hidden", "last_seen_status"])
 


### PR DESCRIPTION
 Default value of `c.last_seen_status` is 0, if calculation is not viewed